### PR TITLE
Dockerize env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:10
+
+ENV DEBIAN_FRONTEND noninteractive
+
+WORKDIR /node_app
+
+COPY package.json /node_app/
+RUN npm install .
+
+COPY . /node_app
+
+CMD ["node","start.js"]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ This is built using the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herok
 
 To run it locally, clone it down, run `npm install` and then `npm start`. It'll then tell you a port to go to in the browser.
 
-Alternatviely run it via docker & docker-compose
+#### Alternatviely run it via docker & docker-compose
+Depends on [docker install](https://docs.docker.com/install/) and [docker-compose install](https://docs.docker.com/compose/install/)
 1. `docker-compose build`
 2. `docker-compose up`
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There is a [worksheet](/worksheet.md), and there is also a list of [answers](ans
 ## What testing tools to use
 I would recommend working through the site in the following order:
 
-- Can you access everything by pressing the tab key? 
+- Can you access everything by pressing the tab key?
 - Does WAVE show any errors, or highlight any issues with the HTML structure?
 - Does the colour contrast tab on [WAVE](http://wave.webaim.org/) throw up any errors?
 - If you run the [Dark Mode browser extension](https://mybrowseraddon.com/dark-mode.html), can you see any issues with the site?
@@ -21,9 +21,19 @@ Government Digital Services have recently published [how to conduct a basic acce
 Testing like this is a good way to identify basic accessibility issues. It would not replace an audit against WCAG 2.1 to level AA, and its ~50 criteria. Why still do it? These are tests that are quick to run, and it's easier to fix accessibility issues at the start, rather than the end.
 
 ## How to run locally
-This is built using the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs). 
+This is built using the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs).
 
 To run it locally, clone it down, run `npm install` and then `npm start`. It'll then tell you a port to go to in the browser.
+
+Alternatviely run it via docker & docker-compose
+1. `docker-compose build`
+2. `docker-compose up`
+
+Or get a bash console where you can run `npm` cmds via the built container (ensure step 1 above is done)
+`docker-compose run --rm --service-ports --entrypoint="bash" goose`
+
+Run the tests via docker
+`docker-compose run --rm --entrypoint="npm run test" goose`
 
 ## Suggesting changes
 Feedback is welcome. Either [submit an issue](https://github.com/ministryofjustice/recording-a-goose-sighting/issues), or [leave a PR](https://github.com/ministryofjustice/recording-a-goose-sighting/pulls).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  goose:
+    build: .
+    volumes:
+      - ./:/node_app
+      - node_modules_cache:/node_app/node_modules
+    ports:
+      - "3000:3000"
+    environment:
+      - PORT=3000
+
+volumes:
+  node_modules_cache:


### PR DESCRIPTION
Allow this repo to be easily spun up with a consistent build env (currently node 10) using docker and docker-compose (must have both installed). 

I left off a bunch off ENV variables for auth and other functionality as i wasn't sure what they do. It would be easy enough to pass them in and ensure they inherit from the running env (if set), happy to add them in :)

Also the tests don't currently pass and the linter fails...maybe this is desired? 

FWIW the docker builds can easily be used in combination with a testing service like travis to run your test for you - it would be something like 
```
services:
  - docker

branches:
  only:
  - master

before_install:
 - docker-compose build

script:
  - docker-compose run -T --rm --entrypoint="npm run test" goose
```