### PR TITLE
Makes date less ambiguous 

### DIFF
--- a/app/views/steps/date-saw-goose.html
+++ b/app/views/steps/date-saw-goose.html
@@ -24,7 +24,7 @@ When did you see the goose - Record a goose sighting
           }
         }, 
         hint: {
-          text: "For example, 12 11 2017"
+          text: "For example, 16 4 2017"
         }
       }) }}
         


### PR DESCRIPTION
The date structure was previously slightly ambigious, as it was 11 12 2017, and it might not have been clear which was date and month. 

16 now has to be the day, as it can't be month, and so it is a bit clearer.

This addresses ticket #14 