### PR TITLE
Remove dark mode issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ I would recommend working through the site in the following order:
 - Can you access everything by pressing the tab key?
 - Does WAVE show any errors, or highlight any issues with the HTML structure?
 - Does the colour contrast tab on [WAVE](http://wave.webaim.org/) throw up any errors?
-- If you run the [Dark Mode browser extension](https://mybrowseraddon.com/dark-mode.html), can you see any issues with the site?
 
 Government Digital Services have recently published [how to conduct a basic accessibility audit](https://www.gov.uk/government/publications/doing-a-basic-accessibility-check-if-you-cant-do-a-detailed-one/doing-a-basic-accessibility-check-if-you-cant-do-a-detailed-one), which is worth a look at too.
 

--- a/app/views/steps/answers.html
+++ b/app/views/steps/answers.html
@@ -9,16 +9,16 @@ Answers - Record a goose sighting
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <a class="govuk-back-link" href="/steps/end">Back</a>
-    
+
     <h1 class="govuk-heading-xl">Accessibility issues in 'Record a goose sighting'</h1>
-    
-  
+
+
     <p>Here is the answer sheet for the 'Record a goose sighting' accessibility testing exercise. There are 19 issues in total.</p>
 
     <p>Some of these issues would not be WCAG (Web Content Accessibility Guidelines) 2.1 failures. But, they could present issues to users with access needs, and WCAG compliance doesn't neccessarily mean that something is accessible.</p>
 
     <h2 class="govuk-heading-m">Pages</h2>
-    
+
     <h3 class="govuk-heading-s">Start page</h3>
 
     <dl class="govuk-body">
@@ -60,10 +60,7 @@ Answers - Record a goose sighting
       <dd>Some screen readers (like JAWS) read the page title out when a page loads. On this page, the page title is 'Boop - Record a goose sighting', which tells the screen reader user nothing about what's on the page. A better format would be the page question, followed by the service name, and followed by whatever it's hosted on - so 'What type of goose did you see - Recording a goose sighting - GOV.UK', if it were on GOV.UK.</dd>
 
       <dt class="govuk-!-font-weight-bold">Visually hidden item you can tab onto</dt>
-      <dd>There is some hidden text on the page, that can be tabbed to. Whilst this isn't a particularly realistic example of this issue, sometimes inputs can get hidden off screen. It can be confusing for keyboard users who are tabbing through the screen, because the focus disappears, and you end up not being entirely sure where or when it's going to reappear, or what would happen if you tried to select the element you were on. If something has focus, it's best that it becomes visible, at least for the duration of it having focus. In many cases think whether there is value for other users by having the content visible at all times.</dd>
-
-      <dt class="govuk-!-font-weight-bold">Transparent text that appears in dark mode</dt>
-      <dd>An attempt was made to hide the text 'ghost goose' on the page - but because color: transparent was used, it isn't properly hidden, and leaks out in dark mode and Windows high contrast mode. The proper fix would be using the 'govuk-visually-hidden' class. This isn't a WCAG 2.1 failure.</dd>
+      <dd>There is a ghost goose hidden on the page! There is some hidden text on the page, that can be tabbed to. Whilst this isn't a particularly realistic example of this issue, sometimes inputs can get hidden off screen. It can be confusing for keyboard users who are tabbing through the screen, because the focus disappears, and you end up not being entirely sure where or when it's going to reappear, or what would happen if you tried to select the element you were on. If something has focus, it's best that it becomes visible, at least for the duration of it having focus. In many cases think whether there is value for other users by having the content visible at all times.</dd>
 
       <dt class="govuk-!-font-weight-bold">Placeholder text</dt>
       <dd>Placeholder text disappears when you start to type. This can be confusing, and if you struggle to remember things, you might then need to delete what you've typed in to remind yourself of what was there, in case it was important. It's best to include information like hints outside of the form field, where it can be seen at all times. This is essential if the placeholder text includes important formatting information.</dd>
@@ -106,7 +103,7 @@ Answers - Record a goose sighting
     </dl>
 
   <h2 class="govuk-heading-m">Want to learn more about Accessibility?</h2>
-  
+
   <ul class="govuk-list govuk-list--bullet">
     <li><a href="https://www.gov.uk/service-manual/helping-people-to-use-your-service/making-your-service-accessible-an-introduction#further-reading">GOV.UK resources about accessibility</a></li>
     <li><a href="https://www.udacity.com/course/web-accessibility--ud891">Udacity course on Accessibility</a></li>

--- a/app/views/steps/goose-type.html
+++ b/app/views/steps/goose-type.html
@@ -13,8 +13,7 @@ Boop - Record a goose sighting
     </h1>
 
     <form class="form" action="/steps/date-saw-goose" method="post">
-      <p style="color: transparent;">Ghost goose</p>
-      <p class="govuk-visually-hidden" tabindex="0">Hidden focusable goose</p>
+      <p class="govuk-visually-hidden" tabindex="0">Ghost goose</p>
 
       <div class="govuk-form-group">
         <label class="govuk-label" for="goose-type">

--- a/app/views/steps/worksheet.html
+++ b/app/views/steps/worksheet.html
@@ -10,18 +10,17 @@ Worksheet - Record a goose sighting
   <div class="govuk-grid-column-two-thirds">
 
     <a class="govuk-back-link" href="/">Back</a>
-    
+
     <h1 class="govuk-heading-xl">Worksheet for 'Recording a goose sighting' accessibility exercise</h1>
 
     <p>You can use this as a worksheet for recording issues you find in this exercise. Copy and paste the below text into a Word Doc, Google Doc, or on your device's notepad.</p>
 
     <h2 class="govuk-heading-m">Testing checklist</h2>
-    
+
     <ul class="govuk-list govuk-list--bullet">
       <li>Can you access everything by <a class="govuk-link" href="https://www.nngroup.com/articles/keyboard-accessibility/">pressing the tab key</a>?</li>
       <li>Does <a class="govuk-link" href="https://wave.webaim.org/">WAVE</a> find any errors?</li>
       <li>Does WAVE's colour contrast tab find any errors?</li>
-      <li>Can you find any issues when using <a class="govuk-link" href="https://chrome.google.com/webstore/detail/dark-mode/dmghijelimhndkbmpgbldicpogfkceaj?hl=en">Dark Mode browser extension</a>?</li>
     </ul>
 
     <p>Government Digital Services have recently published <a class="govuk-link" href="https://www.gov.uk/government/publications/doing-a-basic-accessibility-check-if-you-cant-do-a-detailed-one/doing-a-basic-accessibility-check-if-you-cant-do-a-detailed-one">how to do a basic accessibility check</a>. If you'd like, you could use these checks as an extension task.</p>


### PR DESCRIPTION
There was a 'ghost goose' piece of text that only appeared when you enabled a specific dark mode plugin. The issue is that different dark mode plugins yield different results, and there is no clear preference on which one we should be using. As such, I'm removing this issue for now.