### PR TITLE
Remove answer about end page transparent border

### DIFF
--- a/app/views/steps/answers.html
+++ b/app/views/steps/answers.html
@@ -98,8 +98,6 @@ Answers - Record a goose sighting
       <dt class="govuk-!-font-weight-bold">Animation cannot be stopped.</dt>
       <dd>Moving content such as the happy goose can be a severe distraction for people with conditions such as attention deficit disorders, making it difficult to use the rest of the page. It should run no longer than 5 seconds or be able to be paused or hidden by the users.</dd>
 
-      <dt class="govuk-!-font-weight-bold">Removed transparent border</dt>
-      <dd>When unaltered, the big box at the top has a colour behind it, that gives it visual prominence on the page. If we turn on our dark mode plugin, it loses this. This is because it's been tampered with a little - if you go to this Summary pattern page in the Design System with the dark mode plugin turned on, you'll see a border appears around it. This is because of a transparent border around it. This was used incorrectly earlier, to try to hide the 'ghost goose', but used to positive effect here. Just one example of the many ways in which the Design System is awesome!</dd>
     </dl>
 
   <h2 class="govuk-heading-m">Want to learn more about Accessibility?</h2>


### PR DESCRIPTION
There was one remaining answer that related to dark mode testing, which I've now removed from this exercise. This removes that.