### PR TITLE
Reinstate answers.md file and add link to answers on landing page

### DIFF
--- a/answers.md
+++ b/answers.md
@@ -1,0 +1,5 @@
+# Answers has now moved!
+
+The answers page now lives within the 'Record a goose sighting' service.
+
+[Visit the answers page](/https://record-a-goose-sighting.herokuapp.com/steps/answers)

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -34,6 +34,8 @@
 
       <p>If you'd like to know more about the background, visit the blog post about this, <a href="https://accessibility.blog.gov.uk/2020/01/14/training-people-to-do-accessibility-reviews/">'Training people to do accessibility reviews'.</a></p>
 
+      <p>If you'd like to go straight to the answers, <a href="https://record-a-goose-sighting.herokuapp.com/steps/answers">view the answers page</a> - no cheating though!</p>
+
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
There is a link to the previous answers page location on the GDS blog post about this repo. As it was a markdown file, I can't do a redirect from within the site. For now, I've added the page back ain and added a link to the new page on it.

I've also included a link to the answers on the home page, for anyone who might want to skip straight to them.