### PR TITLE
Fix link to answers page

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -34,7 +34,7 @@
 
       <p>If you'd like to know more about the background, visit the blog post about this, <a href="https://accessibility.blog.gov.uk/2020/01/14/training-people-to-do-accessibility-reviews/">'Training people to do accessibility reviews'.</a></p>
 
-      <p>If you'd like to go straight to the answers, <a href="https://record-a-goose-sighting.herokuapp.com/steps/answers">view the answers page</a> - no cheating though!</p>
+      <p>If you'd like to go straight to the answers, <a href="/steps/answers">view the answers page</a> - no cheating though!</p>
 
     </div>
   </div>


### PR DESCRIPTION
Should be relative, not pointing to the old domain